### PR TITLE
feat: 新增设置静态资源使用 cdn 支持

### DIFF
--- a/404.php
+++ b/404.php
@@ -7,7 +7,7 @@
  * */
 
 
-$url      = get_template_directory_uri();//主题url
+$url      = get_cdn_uri();//主题url
 $page_404 = $url . '/common/404/404.svg';
 $page_css = $url . '/common/404/404.css';
 ?>

--- a/comments.php
+++ b/comments.php
@@ -26,7 +26,7 @@ if ( nicen_theme_showComments() ) {
 		$nickname = $isLogin ? ( $adminUserInfo->exists() ? $adminUserInfo->display_name : '' ) : htmlspecialchars( $currentCommenter['comment_author'] );
 		$email    = $isLogin ? ( $adminUserInfo->exists() ? $adminUserInfo->user_email : '' ) : htmlspecialchars( $currentCommenter['comment_author_email'] );
 		$webUrl   = $isLogin ? site_url() : htmlspecialchars( $currentCommenter['comment_author_url'] );
-		$default  = get_template_directory_uri() . '/assets/images/avatar.svg?ver=' . filemtime( get_template_directory() . '/assets/images/avatar.svg' );
+		$default  = get_cdn_uri() . '/assets/images/avatar.svg?ver=' . filemtime( get_template_directory() . '/assets/images/avatar.svg' );
 		$avatar   = $isLogin ? ( get_avatar_url( $adminUserInfo->ID ) ?? $default ) : $default;
 
 		$reply_to_id = isset( $_GET['replytocom'] ) ? (int) $_GET['replytocom'] : false;

--- a/include/admin/editor_plugin.php
+++ b/include/admin/editor_plugin.php
@@ -10,7 +10,7 @@ function nicen_theme_admin_init() {
 	if ( nicen_theme_config( 'document_theme_Gutenberg', false ) ) {
 		add_filter( 'use_block_editor_for_post', '__return_false' );
 	}
-	
+
 	//禁止新版小工具
     add_filter( 'gutenberg_use_widgets_block_editor', '__return_false' );
     add_filter( 'use_widgets_block_editor', '__return_false' );
@@ -32,17 +32,17 @@ function nicen_theme_admin_init() {
             /*
              * 引入插件的js
              * */
-            $plugin_array['success']  = get_template_directory_uri() . '/common/plugins/success.js';/*指定要加载的插件*/
-            $plugin_array['alert']    = get_template_directory_uri() . '/common/plugins/alert.js';/*指定要加载的插件*/
-            $plugin_array['error']    = get_template_directory_uri() . '/common/plugins/error.js';/*指定要加载的插件*/
-            $plugin_array['h1']       = get_template_directory_uri() . '/common/plugins/h1.js';/*指定要加载的插件*/
-            $plugin_array['h2']       = get_template_directory_uri() . '/common/plugins/h2.js';/*指定要加载的插件*/
-            $plugin_array['h3']       = get_template_directory_uri() . '/common/plugins/h3.js';/*指定要加载的插件*/
-            $plugin_array['code']     = get_template_directory_uri() . '/common/plugins/code.js';/*指定要加载的插件*/
-            $plugin_array['lightbox'] = get_template_directory_uri() . '/common/plugins/lightbox.js';/*指定要加载的插件*/
-            $plugin_array['mark']     = get_template_directory_uri() . '/common/plugins/mark.js';/*指定要加载的插件*/
-            $plugin_array['table']    = get_template_directory_uri() . '/common/plugins/table.js';/*指定要加载的插件*/
-            $plugin_array['u']        = get_template_directory_uri() . '/common/plugins/u.js';/*指定要加载的插件*/
+            $plugin_array['success']  = get_cdn_uri() . '/common/plugins/success.js';/*指定要加载的插件*/
+            $plugin_array['alert']    = get_cdn_uri() . '/common/plugins/alert.js';/*指定要加载的插件*/
+            $plugin_array['error']    = get_cdn_uri() . '/common/plugins/error.js';/*指定要加载的插件*/
+            $plugin_array['h1']       = get_cdn_uri() . '/common/plugins/h1.js';/*指定要加载的插件*/
+            $plugin_array['h2']       = get_cdn_uri() . '/common/plugins/h2.js';/*指定要加载的插件*/
+            $plugin_array['h3']       = get_cdn_uri() . '/common/plugins/h3.js';/*指定要加载的插件*/
+            $plugin_array['code']     = get_cdn_uri() . '/common/plugins/code.js';/*指定要加载的插件*/
+            $plugin_array['lightbox'] = get_cdn_uri() . '/common/plugins/lightbox.js';/*指定要加载的插件*/
+            $plugin_array['mark']     = get_cdn_uri() . '/common/plugins/mark.js';/*指定要加载的插件*/
+            $plugin_array['table']    = get_cdn_uri() . '/common/plugins/table.js';/*指定要加载的插件*/
+            $plugin_array['u']        = get_cdn_uri() . '/common/plugins/u.js';/*指定要加载的插件*/
 
 
             return $plugin_array;

--- a/include/admin/extra.php
+++ b/include/admin/extra.php
@@ -5,7 +5,7 @@
  * */
 
 function nicen_theme_admin_edit_load_style( $mce_css ) {
-    $url = get_template_directory_uri();//主题url
+    $url = get_cdn_uri();//主题url
     if ( ! is_array( $mce_css ) ) {
         $mce_css = explode( ',', $mce_css );
     }

--- a/include/admin/load.php
+++ b/include/admin/load.php
@@ -7,7 +7,7 @@ function nicen_theme_admin_load_source() {
 
 
     $root = get_template_directory(); //主题路径
-    $url  = get_template_directory_uri();//主题url
+    $url  = get_cdn_uri();//主题url
     global $desination_configs;
 
 
@@ -61,7 +61,7 @@ if ( strpos( $_SERVER['QUERY_STRING'] ?? "", 'document_theme' ) !== false ) {
 function nicen_theme_widget_admin_load() {
 
     $root = get_template_directory(); //主题路径
-    $url  = get_template_directory_uri();//主题url
+    $url  = get_cdn_uri();//主题url
     wp_enqueue_style( 'widgetcss', $url . '/common/widget/widget.css', array(), filemtime( $root . '/common/widget/widget.css' ) );
     wp_enqueue_style( 'jqueryuicss', $url . '/assets/theme/jquery-ui.min.css', array() );
     wp_enqueue_script( 'widgetjs', $url . '/common/widget/widget.js', array(

--- a/include/admin/load.php
+++ b/include/admin/load.php
@@ -7,7 +7,7 @@ function nicen_theme_admin_load_source() {
 
 
     $root = get_template_directory(); //主题路径
-    $url  = get_cdn_uri();//主题url
+    $url  = get_template_directory_uri();//主题url
     global $desination_configs;
 
 

--- a/include/config.php
+++ b/include/config.php
@@ -111,6 +111,14 @@ const ADMIN = [
 						]
 					],
 					[
+						'id'       => 'document_cdn_uri',
+						'title'    => '静态资源 CDN 前缀',
+						'callback' => 'nicen_theme_form_input',
+						'args'     => [
+							'tip' => '为空则不使用 CDN。如 https://fastly.jsdelivr.net/gh/friend-nicen/theme-document@master',
+						],
+					],
+					[
 						'id'       => 'document_catelog_mode',
 						'title'    => '文章目录解析模式',
 						'callback' => 'nicen_theme_form_select',
@@ -759,6 +767,7 @@ define( "CONFIG", [
 	'document_thumbnail_default'  => get_theme_root_uri() . '/destination/assets/images/default.png',
 	"document_Gravatar"           => 'gravatar.loli.net/avatar',
 	//默认替换的gavatar源
+	'document_cdn_uri'  	      => '',
 	"document_theme_color"        => '#3eaf7c',
 	"document_show_copyright"     => 1,
 	//主题色

--- a/include/config.php
+++ b/include/config.php
@@ -115,7 +115,7 @@ const ADMIN = [
 						'title'    => '静态资源 CDN 前缀',
 						'callback' => 'nicen_theme_form_input',
 						'args'     => [
-							'tip' => '为空则不使用 CDN。如 https://fastly.jsdelivr.net/gh/friend-nicen/theme-document@master',
+							'tip' => '为空则不使用 CDN。示例：https://fastly.jsdelivr.net/gh/friend-nicen/theme-document',
 						],
 					],
 					[

--- a/include/functions/common.php
+++ b/include/functions/common.php
@@ -1073,7 +1073,15 @@ function get_cdn_uri() {
     $cdn_uri = nicen_theme_config('document_cdn_uri', false);
     if (empty($cdn_uri)) {
         $cdn_uri = get_template_directory_uri();
-    }
+    } else {
+		// 添加 DOCUMENT_VERSION 版本检测：若没有包含 @ 符号并且没有以 / 结尾，则自动加上版本号
+		if (strpos($cdn_uri, '@') === false && substr($cdn_uri, -1) !== '/') {
+			$cdn_uri .= '@' . DOCUMENT_VERSION;
+		} else {
+			// 去掉末尾的 / 符号
+			$cdn_uri = rtrim($cdn_uri, '/');
+		}
+	}
 
     return $cdn_uri;
 }

--- a/include/functions/common.php
+++ b/include/functions/common.php
@@ -1065,3 +1065,15 @@ function get_new_post_modified_time( $format ) {
 	}
 
 }
+
+/**
+ * 获取CDN地址
+ */
+function get_cdn_uri() {
+    $cdn_uri = nicen_theme_config('document_cdn_uri', false);
+    if (empty($cdn_uri)) {
+        $cdn_uri = get_template_directory_uri();
+    }
+
+    return $cdn_uri;
+}

--- a/include/themes/emoji.php
+++ b/include/themes/emoji.php
@@ -19,10 +19,10 @@ function nicen_theme_textToEmoji( $comment_ID ) {
 
     $comment = get_comment( $comment_ID );
     $html    = $comment->comment_content;
-    $path    = get_template_directory_uri() . "/assets/smilies/"; //主题目录
+    $path    = get_cdn_uri() . "/assets/smilies/"; //主题目录
     $dir     = get_template_directory() . "/assets/smilies/"; //主题目录
 
-    
+
     /*
      * 匹配是否有表情
      * */

--- a/include/themes/load.php
+++ b/include/themes/load.php
@@ -8,7 +8,7 @@ function nicen_theme_load_source() {
 
 
 	$root = get_template_directory(); //主题路径
-	$url  = get_template_directory_uri();//主题url
+	$url  = get_cdn_uri();//主题url
 
 	/* 底部推荐区域 */
 	if ( is_active_sidebar( 'content_down' ) ) {
@@ -32,7 +32,7 @@ function nicen_theme_load_source() {
 
 
 	/*主题的style.css*/
-	wp_enqueue_style( 'main-styles', get_stylesheet_uri(), array(), filemtime( $root . '/style.css' ) );
+	wp_enqueue_style( 'main-styles', $url . '/style.css', array(), filemtime( $root . '/style.css' ) );
 
 	/*
 	 * 去除无用的css

--- a/include/widget/components/Author.php
+++ b/include/widget/components/Author.php
@@ -93,14 +93,14 @@ class Author extends WP_Widget {
 			'title'   => '头像',
 			'type'    => 'text',
 			'field'   => 'avatar',
-			'default' => get_template_directory_uri() . '/assets/images/avatars.jpg',
+			'default' => get_cdn_uri() . '/assets/images/avatars.jpg',
 		] );
 
 		widget_media( $this, $instance, [
 			'title'   => '背景',
 			'type'    => 'text',
 			'field'   => 'beijin',
-			'default' => get_template_directory_uri() . '/assets/images/bg.jpg',
+			'default' => get_cdn_uri() . '/assets/images/bg.jpg',
 		] );
 
 		?>

--- a/template/emoji.php
+++ b/template/emoji.php
@@ -4,7 +4,7 @@
 * @date 2022/10/17
 * 表情模板
 */
-$url = get_template_directory_uri();
+$url = get_cdn_uri();
 ?>
 
 <ul class="emoji-list">

--- a/template/index/emoji.php
+++ b/template/index/emoji.php
@@ -4,7 +4,7 @@
 * @date 2022/10/17
 * 表情模板
 */
-$url = get_template_directory_uri();
+$url = get_cdn_uri();
 ?>
 
 <ul class="emoji-list">

--- a/template/index/empty.php
+++ b/template/index/empty.php
@@ -6,7 +6,7 @@
  * @date 2022-07-08
  * */
 
-$url      = get_template_directory_uri();//主题url
+$url      = get_cdn_uri();//主题url
 $page_404 = $url . '/assets/images/empty.svg';
 $page_css = $url . '/common/404/404.css';
 ?>

--- a/template/index/password.php
+++ b/template/index/password.php
@@ -7,7 +7,7 @@
  * */
 
 
-$url     = get_template_directory_uri();//主题url
+$url     = get_cdn_uri();//主题url
 $protect = $url . '/assets/images/empty.svg';
 ?>
     <div class="password">

--- a/template/index/sidebar-left.php
+++ b/template/index/sidebar-left.php
@@ -35,11 +35,11 @@ if ( nicen_theme_showCatelog() ) {
                 <div class="icp-beian">
                     <div>
                         <span class="number"><?php echo nicen_theme_getPostNice( get_the_ID() ); ?></span>
-                        <img src="<?php echo get_template_directory_uri(); ?>/assets/images/zan.svg" title="点赞"/>
+                        <img src="<?php echo get_cdn_uri(); ?>/assets/images/zan.svg" title="点赞"/>
                     </div>
                     <div>
                         <span class="number"><?php echo nicen_theme_getPostBad( get_the_ID() ); ?></span>
-                        <img src="<?php echo get_template_directory_uri(); ?>/assets/images/cai.svg" title="踩"/>
+                        <img src="<?php echo get_cdn_uri(); ?>/assets/images/cai.svg" title="踩"/>
                     </div>
                 </div>
             </aside>

--- a/template/widget/recommend.php
+++ b/template/widget/recommend.php
@@ -86,14 +86,14 @@ global $table_prefix, $wpdb;
 					 * */
 					if ( is_single() && ! empty( $category ) ) {
 
-						$sql = 'select a.post_id,a.meta_value 
-                                                from `' . $table_prefix . 'postmeta` As a join `' . $table_prefix . 'term_relationships` as b on a.post_id = b.object_id 
+						$sql = 'select a.post_id,a.meta_value
+                                                from `' . $table_prefix . 'postmeta` As a join `' . $table_prefix . 'term_relationships` as b on a.post_id = b.object_id
                                                 where a.meta_key = "post_views_count" and b.term_taxonomy_id in (' . join( ',', $category ) . ') order by a.meta_value+0 DESC limit ' . $number;
 
 					} else {
 
-						$sql = 'select a.post_id,a.meta_value 
-                                                from `' . $table_prefix . 'postmeta` As a join `' . $table_prefix . 'term_relationships` as b on a.post_id = b.object_id 
+						$sql = 'select a.post_id,a.meta_value
+                                                from `' . $table_prefix . 'postmeta` As a join `' . $table_prefix . 'term_relationships` as b on a.post_id = b.object_id
                                                 where a.meta_key = "post_views_count" order by a.meta_value+0 DESC limit ' . $number;
 
 					}
@@ -148,13 +148,13 @@ global $table_prefix, $wpdb;
 		<?php
 
 		if ( $count == 0 ) {
-			$url = get_template_directory_uri() . "/assets/images/nothing.svg"; //主题url
+			$url = get_cdn_uri() . "/assets/images/nothing.svg"; //主题url
 			echo '<div class="empty">
                             <img src="' . $url . '" title="暂无相关文章" />
                             <span>暂无可推荐内容</span>
                       </div>';
 		} else {
-			echo '         
+			echo '
                     <div class="swiper-button-next"></div>
                     <div class="swiper-button-prev"></div>';
 		}

--- a/template/widget/swiper.php
+++ b/template/widget/swiper.php
@@ -5,7 +5,7 @@
  * @author 友人a丶
  * @date 2022-07-08
  * */
-$default = get_template_directory_uri() . "/assets/images/default.png";
+$default = get_cdn_uri() . "/assets/images/default.png";
 
 ?>
 <div class="swiper mySwiper <?php echo $show_in_mobile ? '' : 'mobile'; ?>">


### PR DESCRIPTION
如题，基于 jsdelivr.net 的 gh 加速服务，可以支持对静态资源的加速缓存访问，从而可以一定程度上减少对服务器的压力。

示例：

```
https://github.com/friend-nicen/theme-document/blob/1.2.108/assets/theme/antd.min.js
```
文件可以通过如下形式访问：
```
https://fastly.jsdelivr.net/gh/friend-nicen/theme-document@1.2.108/assets/theme/antd.min.js
```

只需要设置 cdn 前缀为 `https://fastly.jsdelivr.net/gh/friend-nicen/theme-document` 或 `https://fastly.jsdelivr.net/gh/friend-nicen/theme-document@1.2.108/` 即可。
