### PR TITLE
feat: prism 支持 dark 模式

### DIFF
--- a/common/prism/prism.dark.css
+++ b/common/prism/prism.dark.css
@@ -1,0 +1,248 @@
+/* PrismJS 1.30.0
+https://prismjs.com/download#themes=prism-dark&languages=markup+css+clike+javascript+abap+abnf+actionscript+ada+agda+al+antlr4+apacheconf+apex+apl+applescript+aql+arduino+arff+armasm+arturo+asciidoc+aspnet+asm6502+asmatmel+autohotkey+autoit+avisynth+avro-idl+awk+bash+basic+batch+bbcode+bbj+bicep+birb+bison+bnf+bqn+brainfuck+brightscript+bro+bsl+c+csharp+cpp+cfscript+chaiscript+cil+cilkc+cilkcpp+clojure+cmake+cobol+coffeescript+concurnas+csp+cooklang+coq+crystal+css-extras+csv+cue+cypher+d+dart+dataweave+dax+dhall+diff+django+dns-zone-file+docker+dot+ebnf+editorconfig+eiffel+ejs+elixir+elm+etlua+erb+erlang+excel-formula+fsharp+factor+false+firestore-security-rules+flow+fortran+ftl+gml+gap+gcode+gdscript+gedcom+gettext+gherkin+git+glsl+gn+linker-script+go+go-module+gradle+graphql+groovy+haml+handlebars+haskell+haxe+hcl+hlsl+hoon+http+hpkp+hsts+ichigojam+icon+icu-message-format+idris+ignore+inform7+ini+io+j+java+javadoc+javadoclike+javastacktrace+jexl+jolie+jq+jsdoc+js-extras+json+json5+jsonp+jsstacktrace+js-templates+julia+keepalived+keyman+kotlin+kumir+kusto+latex+latte+less+lilypond+liquid+lisp+livescript+llvm+log+lolcode+lua+magma+makefile+markdown+markup-templating+mata+matlab+maxscript+mel+mermaid+metafont+mizar+mongodb+monkey+moonscript+n1ql+n4js+nand2tetris-hdl+naniscript+nasm+neon+nevod+nginx+nim+nix+nsis+objectivec+ocaml+odin+opencl+openqasm+oz+parigp+parser+pascal+pascaligo+psl+pcaxis+peoplecode+perl+php+phpdoc+php-extras+plant-uml+plsql+powerquery+powershell+processing+prolog+promql+properties+protobuf+pug+puppet+pure+purebasic+purescript+python+qsharp+q+qml+qore+r+racket+cshtml+jsx+tsx+reason+regex+rego+renpy+rescript+rest+rip+roboconf+robotframework+ruby+rust+sas+sass+scss+scala+scheme+shell-session+smali+smalltalk+smarty+sml+solidity+solution-file+soy+sparql+splunk-spl+sqf+sql+squirrel+stan+stata+iecst+stylus+supercollider+swift+systemd+t4-templating+t4-cs+t4-vb+tap+tcl+tt2+textile+toml+tremor+turtle+twig+typescript+typoscript+unrealscript+uorazor+uri+v+vala+vbnet+velocity+verilog+vhdl+vim+visual-basic+warpscript+wasm+web-idl+wgsl+wiki+wolfram+wren+xeora+xml-doc+xojo+xquery+yaml+yang+zig&plugins=line-highlight */
+/**
+ * prism.js Dark theme for JavaScript, CSS and HTML
+ * Based on the slides of the talk “/Reg(exp){2}lained/”
+ * @author Lea Verou
+ */
+.dark {
+
+	code[class*="language-"],
+	pre[class*="language-"] {
+		color: white;
+		background: none;
+		text-shadow: 0 -.1em .2em black;
+		font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+		font-size: 1em;
+		text-align: left;
+		white-space: pre;
+		word-spacing: normal;
+		word-break: normal;
+		word-wrap: normal;
+		line-height: 1.5;
+
+		-moz-tab-size: 4;
+		-o-tab-size: 4;
+		tab-size: 4;
+
+		-webkit-hyphens: none;
+		-moz-hyphens: none;
+		-ms-hyphens: none;
+		hyphens: none;
+	}
+
+	@media print {
+
+		code[class*="language-"],
+		pre[class*="language-"] {
+			text-shadow: none;
+		}
+	}
+
+	pre[class*="language-"],
+	:not(pre)>code[class*="language-"] {
+		background: hsl(30, 20%, 25%);
+	}
+
+	/* Code blocks */
+	pre[class*="language-"] {
+		padding: 1em;
+		margin: .5em 0;
+		overflow: auto;
+		border: .3em solid hsl(30, 20%, 40%);
+		border-radius: .5em;
+		box-shadow: 1px 1px .5em black inset;
+	}
+
+	/* Inline code */
+	:not(pre)>code[class*="language-"] {
+		padding: .15em .2em .05em;
+		border-radius: .3em;
+		border: .13em solid hsl(30, 20%, 40%);
+		box-shadow: 1px 1px .3em -.1em black inset;
+		white-space: normal;
+	}
+
+	.token.comment,
+	.token.prolog,
+	.token.doctype,
+	.token.cdata {
+		color: hsl(30, 20%, 50%);
+	}
+
+	.token.punctuation {
+		opacity: .7;
+	}
+
+	.token.namespace {
+		opacity: .7;
+	}
+
+	.token.property,
+	.token.tag,
+	.token.boolean,
+	.token.number,
+	.token.constant,
+	.token.symbol {
+		color: hsl(350, 40%, 70%);
+	}
+
+	.token.selector,
+	.token.attr-name,
+	.token.string,
+	.token.char,
+	.token.builtin,
+	.token.inserted {
+		color: hsl(75, 70%, 60%);
+	}
+
+	.token.operator,
+	.token.entity,
+	.token.url,
+	.language-css .token.string,
+	.style .token.string,
+	.token.variable {
+		color: hsl(40, 90%, 60%);
+	}
+
+	.token.atrule,
+	.token.attr-value,
+	.token.keyword {
+		color: hsl(350, 40%, 70%);
+	}
+
+	.token.regex,
+	.token.important {
+		color: #e90;
+	}
+
+	.token.important,
+	.token.bold {
+		font-weight: bold;
+	}
+
+	.token.italic {
+		font-style: italic;
+	}
+
+	.token.entity {
+		cursor: help;
+	}
+
+	.token.deleted {
+		color: red;
+	}
+
+	pre[data-line] {
+		position: relative;
+		padding: 1em 0 1em 3em;
+	}
+
+	.line-highlight {
+		position: absolute;
+		left: 0;
+		right: 0;
+		padding: inherit 0;
+		margin-top: 1em;
+		/* Same as .prism’s padding-top */
+
+		background: hsla(24, 20%, 50%, .08);
+		background: linear-gradient(to right, hsla(24, 20%, 50%, .1) 70%, hsla(24, 20%, 50%, 0));
+
+		pointer-events: none;
+
+		line-height: inherit;
+		white-space: pre;
+	}
+
+	@media print {
+		.line-highlight {
+			/*
+			* This will prevent browsers from replacing the background color with white.
+			* It's necessary because the element is layered on top of the displayed code.
+			*/
+			-webkit-print-color-adjust: exact;
+			color-adjust: exact;
+		}
+	}
+
+	.line-highlight:before,
+	.line-highlight[data-end]:after {
+		content: attr(data-start);
+		position: absolute;
+		top: .4em;
+		left: .6em;
+		min-width: 1em;
+		padding: 0 .5em;
+		background-color: hsla(24, 20%, 50%, .4);
+		color: hsl(24, 20%, 95%);
+		font: bold 65%/1.5 sans-serif;
+		text-align: center;
+		vertical-align: .3em;
+		border-radius: 999px;
+		text-shadow: none;
+		box-shadow: 0 1px white;
+	}
+
+	.line-highlight[data-end]:after {
+		content: attr(data-end);
+		top: auto;
+		bottom: .4em;
+	}
+
+	.line-numbers .line-highlight:before,
+	.line-numbers .line-highlight:after {
+		content: none;
+	}
+
+	pre[id].linkable-line-numbers span.line-numbers-rows {
+		pointer-events: all;
+	}
+
+	pre[id].linkable-line-numbers span.line-numbers-rows>span:before {
+		cursor: pointer;
+	}
+
+	pre[id].linkable-line-numbers span.line-numbers-rows>span:hover:before {
+		background-color: rgba(128, 128, 128, .2);
+	}
+
+	pre[class*=language-].line-numbers {
+		position: relative;
+		padding-left: 3.8em;
+		counter-reset: linenumber
+	}
+
+	pre[class*=language-].line-numbers>code {
+		position: relative;
+		white-space: inherit
+	}
+
+	.line-numbers .line-numbers-rows {
+		position: absolute;
+		pointer-events: none;
+		top: 0;
+		font-size: 100%;
+		left: -3.8em;
+		width: 3em;
+		letter-spacing: -1px;
+		border-right: 1px solid #999;
+		-webkit-user-select: none;
+		-moz-user-select: none;
+		-ms-user-select: none;
+		user-select: none
+	}
+
+	.line-numbers-rows>span {
+		display: block;
+		counter-increment: linenumber
+	}
+
+	.line-numbers-rows>span:before {
+		content: counter(linenumber);
+		color: #999;
+		display: block;
+		padding-right: .8em;
+		text-align: right
+	}
+}

--- a/include/themes/load.php
+++ b/include/themes/load.php
@@ -71,6 +71,7 @@ function nicen_theme_load_source() {
 		wp_enqueue_script( 'viewerjs', $url . '/common/viewer/viewer.min.js', array(), filemtime( $root . '/common/viewer/viewer.min.js' ), false );
 		wp_enqueue_script( 'prism', $url . '/common/prism/prism.js', array(), filemtime( $root . '/common/prism/prism.js' ), false );
 		wp_enqueue_style( 'prism', $url . '/common/prism/prism.css', array(), filemtime( $root . '/common/prism/prism.css' ) );
+		wp_enqueue_style( 'prism-dark', $url . '/common/prism/prism.dark.css', array(), filemtime( $root . '/common/prism/prism.dark.css' ) );
 		wp_enqueue_style( 'viewercss', $url . '/common/viewer/viewer.min.css', array(), filemtime( $root . '/common/viewer/viewer.min.css' ) );
 
 	}


### PR DESCRIPTION
如题，当前代码渲染在 dark 模式下会界面表现较差，主要是 prism 没有对应加载 dark 样式。
本 PR 通过简单的引入 prism-dark.css 样式予以改善。

#44 