### PR TITLE
feat: 优化 <blockquote> 样式，增强视觉区分度

### DIFF
--- a/style.css
+++ b/style.css
@@ -2313,3 +2313,18 @@ html {
         display: none; }
       html body .main-container .main-main .div-info .comment-form .comment-form-main .comment-textarea .emoji-list {
         width: 80%; } }
+
+
+html body .main-container .main-main .main-content .main-article blockquote{
+  margin: 1rem 0;
+  padding: .75rem 1rem;
+  border-left: 4px solid var(--theme-color);
+  background: rgba(0,0,0,.04);
+  border-radius: 6px;
+}
+
+html body .main-container .main-main .main-content .main-article blockquote p{
+  margin: .4rem 0;
+}
+
+


### PR DESCRIPTION
在当前主题中，\<blockquote> 块的视觉区分度不高，不容易与普通正文区分。如图：

<img width="934" height="970" alt="image" src="https://github.com/user-attachments/assets/187f4909-5b75-4cfa-a70a-aaf38d90c386" />

来自我的博客
https://www.haibinlaiblog.top/index.php/where-do-interrupts-happen/

该部分源代码：

```txt
在此例中，`mov`指令的退休属于"**执行受限**"（execution limited）——即其退休周期完全取决于执行完成时间，与退休引擎本身的处理细节无关。相反，其他`nop`指令的退休则受退休机制行为（retirement behavior）支配：它们早已"准备就绪"，却因按序退休指针被尚未执行完毕的`mov`指令阻塞而无法退休。

> **Execution limited**
> `mov` 指令之所以不能退休，是因为它自身的**执行阶段还没完成**（它在慢悠悠地等内存数据）。它的退休时间完全由它自己的执行速度决定。
>
> **Retirement limited**
> `nop` 指令早就**执行完毕了**，状态是“准备就绪”。但它们还是不能退休，原因是 CPU 必须**按顺序退休指令**。


```

我们在style.css 中加入解析。
修改后：

<img width="923" height="515" alt="image" src="https://github.com/user-attachments/assets/ce64b41f-32ee-4a96-91f5-baaed3342d3a" />


改进引用块（\<blockquote>）的展示效果
